### PR TITLE
docs: add GeekyAnts company info and service links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ A dashboard made by using Svelte and Sapper, inspired from SB-Admin Dashboard.
 
 Check the live demo **[here](https://objective-benz-e53b25.netlify.com/)**
 
+
+## About
+
+   SB Admin rebuilt with Svelte by [GeekyAnts](https://geekyants.com?utm_source=github&utm_medium=opensource&utm_campaign=sb-admin-svelte).
+
+   Looking for [web engineering](https://geekyants.com/service/hire-web-app-development-services?utm_source=github&utm_medium=opensource&utm_campaign=sb-admin-svelte)
+   or [full stack development](https://geekyants.com/service/full-stack-app-development-services?utm_source=github&utm_medium=opensource&utm_campaign=sb-admin-svelte)?
+   [Let's talk](https://geekyants.com/hire?utm_source=github&utm_medium=opensource&utm_campaign=sb-admin-svelte).
+
 ## Getting started
 
 ### Clone


### PR DESCRIPTION
## Summary
- Added GeekyAnts company information and attribution
- Added relevant service links with UTM tracking
- Enhanced README with professional support section

## Links Added
- Company homepage
- Relevant service pages (React Native/Flutter/Backend as applicable)
- Contact/hire page

## UTM Tracking
All links include proper UTM parameters for analytics:
- utm_source=github
- utm_medium=opensource
- utm_campaign=sb-admin-svelte

## Checklist
- [x] Content reads naturally
- [x] Links are contextually relevant
- [x] UTM parameters are correct
- [x] No more than 6 links per repo
- [x] Follows SEO best practices